### PR TITLE
Serve frontend locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,33 @@ Store and search your personal principles across web and mobile apps.
 ## Deployment
 
 Backend is deployed on Heroku via `Procfile` and frontend is served from Vercel using `vercel.json`.
+
+## Local Hosting
+
+To run everything offline on your machine:
+
+1. Install backend dependencies and create a virtual environment:
+
+   ```bash
+   cd backend
+   python -m venv venv
+   . venv/bin/activate
+   pip install -r requirements.txt
+   ```
+
+2. Build the frontend so it can be served by Flask:
+
+   ```bash
+   cd ../frontend
+   npm install
+   npm run build
+   ```
+
+3. Start the backend which will also serve the compiled frontend:
+
+   ```bash
+   cd ../backend
+   FLASK_APP=app.core flask run
+   ```
+
+Visit `http://localhost:5000` to use the app without any cloud services.

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,4 +1,5 @@
-from flask import Flask
+from pathlib import Path
+from flask import Flask, send_from_directory
 from flask_cors import CORS
 from flask_jwt_extended import JWTManager
 
@@ -19,5 +20,15 @@ def create_app() -> Flask:
 
     app.register_blueprint(auth_bp, url_prefix="/api/auth")
     app.register_blueprint(principles_bp, url_prefix="/api/principles")
+
+    build_dir = Path(__file__).resolve().parents[2] / "frontend" / "build"
+
+    @app.route('/', defaults={'path': ''})
+    @app.route('/<path:path>')
+    def serve_frontend(path: str):
+        full_path = build_dir / path
+        if path and full_path.exists():
+            return send_from_directory(build_dir, path)
+        return send_from_directory(build_dir, 'index.html')
 
     return app

--- a/backend/app/principles/routes.py
+++ b/backend/app/principles/routes.py
@@ -1,16 +1,19 @@
 from flask import Blueprint, request, jsonify
 from flask_jwt_extended import jwt_required, get_jwt_identity
 import os
-import huggingface_hub
 
-# sentence-transformers 2.2 imports `cached_download` from
-# `huggingface_hub`, which was removed in newer versions. Provide a
-# backwards compatible alias so the import succeeds without pinning an
-# older hub version.
-if not hasattr(huggingface_hub, "cached_download"):
-    huggingface_hub.cached_download = huggingface_hub.hf_hub_download
+OFFLINE = os.getenv("OFFLINE_TESTS")
+if not OFFLINE:
+    import huggingface_hub
 
-from sentence_transformers import SentenceTransformer
+    # sentence-transformers 2.2 imports `cached_download` from
+    # `huggingface_hub`, which was removed in newer versions. Provide a
+    # backwards compatible alias so the import succeeds without pinning an
+    # older hub version.
+    if not hasattr(huggingface_hub, "cached_download"):
+        huggingface_hub.cached_download = huggingface_hub.hf_hub_download
+
+    from sentence_transformers import SentenceTransformer
 from sqlalchemy.sql import text
 from sqlalchemy import desc
 
@@ -19,7 +22,7 @@ from ..schemas import PrincipleOut
 from ..config import Config
 
 principles_bp = Blueprint('principles', __name__)
-if os.getenv("OFFLINE_TESTS"):
+if OFFLINE:
     class _DummyModel:
         def encode(self, text):
             return [0.0]


### PR DESCRIPTION
## Summary
- add instructions for hosting the project offline
- allow Flask backend to serve static frontend build
- import heavy ML dependencies only in normal mode

## Testing
- `make test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846e6a03d18832d8eb7587a42b251ad