### PR TITLE
Update SpaCy

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,6 +6,6 @@ psycopg2-binary==2.9.6
 SQLAlchemy==2.0.23
 alembic==1.12.1
 sentence-transformers==2.2.2
-spacy==3.5.3
+spacy>=3.7
 pytest==7.4.0
 huggingface-hub==0.15.1


### PR DESCRIPTION
## Summary
- bump spaCy to 3.7 or greater for Python 3.11 support

## Testing
- `python -m pip install --upgrade pip wheel setuptools`
- `pip install -r backend/requirements.txt`
- `python -m spacy info`

------
https://chatgpt.com/codex/tasks/task_e_684716802a90832d81b7caf081d55412