### PR TITLE
Require DATABASE_URL env

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,14 @@ To run everything offline on your machine:
    ```
 
 2. Create a PostgreSQL database (for example with `createdb wisdomflow`) and
-   set the connection string in the `DATABASE_URL` environment variable. SQLite
-   cannot be used because UUID and vector columns are unsupported. Run the
-   migrations to initialize the schema:
+   **export** the connection string in the `DATABASE_URL` environment variable:
+
+   ```bash
+   export DATABASE_URL=postgresql://<user>:<password>@localhost/wisdomflow
+   ```
+
+   SQLite cannot be used because UUID and vector columns are unsupported.
+   After exporting `DATABASE_URL`, run the migrations to initialize the schema:
 
    ```bash
    make migrate

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -4,7 +4,9 @@ from datetime import timedelta
 
 class Config:
     SECRET_KEY = os.environ.get("SECRET_KEY", "dev")
-    SQLALCHEMY_DATABASE_URI = os.environ.get("DATABASE_URL", "sqlite:///db.sqlite3")
+    SQLALCHEMY_DATABASE_URI = os.environ.get("DATABASE_URL")
+    if not SQLALCHEMY_DATABASE_URI:
+        raise RuntimeError("DATABASE_URL must point to a PostgreSQL database")
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     ACCESS_TOKEN_EXPIRES_MINUTES = 15
     REFRESH_TOKEN_EXPIRES_MINUTES = 60 * 24


### PR DESCRIPTION
## Summary
- enforce `DATABASE_URL` in backend config
- document exporting `DATABASE_URL` before migrations

## Testing
- `DATABASE_URL=postgresql://localhost/dummy make test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68471b0adc34832dbb89d7d4f81dec2b