### PR TITLE
Add pgvector integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ Store and search your personal principles across web and mobile apps.
 
 Database migrations require a **PostgreSQL** database. SQLite cannot be used
 because the project relies on `UUID` and vector column types which are not
-supported by SQLite.
+supported by SQLite. You must also install the `pgvector` extension in your
+PostgreSQL server so that vector columns work correctly.
 
 ## Deployment
 
@@ -31,9 +32,10 @@ To run everything offline on your machine:
    ```
 
 2. Create a PostgreSQL database (for example with `createdb wisdomflow`) and
-   set the connection string in the `DATABASE_URL` environment variable. SQLite
-   cannot be used because UUID and vector columns are unsupported. Run the
-   migrations to initialize the schema:
+   enable the `pgvector` extension by running `CREATE EXTENSION IF NOT EXISTS
+   vector;`. Set the connection string in the `DATABASE_URL` environment
+   variable. SQLite cannot be used because UUID and vector columns are
+   unsupported. Run the migrations to initialize the schema:
 
    ```bash
    make migrate

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy import func
+from pgvector.sqlalchemy import Vector
 import uuid
 from .db import db
 
@@ -18,7 +19,7 @@ class Principle(db.Model):
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     user_id = db.Column(UUID(as_uuid=True), db.ForeignKey("users.id"), nullable=False)
     text = db.Column(db.Text, nullable=False)
-    embedding = db.Column(db.ARRAY(db.Float), nullable=False)
+    embedding = db.Column(Vector(dim=384))
     created_at = db.Column(db.DateTime, server_default=func.now())
     deleted = db.Column(db.Boolean, default=False)
 

--- a/backend/migrations/versions/21cbf3e1aeb7_init.py
+++ b/backend/migrations/versions/21cbf3e1aeb7_init.py
@@ -9,6 +9,7 @@ from typing import Sequence, Union
 
 from alembic import op
 import sqlalchemy as sa
+from pgvector.sqlalchemy import Vector
 
 
 # revision identifiers, used by Alembic.
@@ -32,7 +33,7 @@ def upgrade() -> None:
     sa.Column('id', sa.UUID(), nullable=False),
     sa.Column('user_id', sa.UUID(), nullable=False),
     sa.Column('text', sa.Text(), nullable=False),
-    sa.Column('embedding', sa.ARRAY(sa.Float()), nullable=False),
+    sa.Column('embedding', Vector(dim=384)),
     sa.Column('created_at', sa.DateTime(), server_default=sa.text('(CURRENT_TIMESTAMP)'), nullable=True),
     sa.Column('deleted', sa.Boolean(), nullable=True),
     sa.ForeignKeyConstraint(['user_id'], ['users.id'], ),

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,3 +9,4 @@ sentence-transformers==2.2.2
 spacy>=3.7
 pytest==7.4.0
 huggingface-hub==0.15.1
+pgvector==0.2.4


### PR DESCRIPTION
## Summary
- enable pgvector in the models and migrations
- require pgvector in backend requirements
- document pgvector extension usage

## Testing
- `make test` *(fails: ModuleNotFoundError: No module named 'flask_cors')*

------
https://chatgpt.com/codex/tasks/task_e_68471b0b8920832d8733ccdbf2d4443d