### PR TITLE
Add search UI and token refresh

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -6,8 +6,22 @@ export async function authFetch(url: string, options: RequestInit = {}) {
   if (token) (headers as any).Authorization = `Bearer ${token}`;
   const res = await fetch(API_BASE + url, { ...options, headers });
   if (res.status === 401) {
-    // TODO refresh token flow
+    const refresh = localStorage.getItem('refresh');
+    if (refresh) {
+      const r = await fetch(API_BASE + '/api/auth/refresh', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ refresh_token: refresh })
+      });
+      if (r.ok) {
+        const data = await r.json();
+        localStorage.setItem('token', data.access_token);
+        localStorage.setItem('refresh', data.refresh_token);
+        return authFetch(url, options);
+      }
+    }
     localStorage.removeItem('token');
+    localStorage.removeItem('refresh');
   }
   return res;
 }

--- a/frontend/src/components/AuthPage.tsx
+++ b/frontend/src/components/AuthPage.tsx
@@ -21,6 +21,7 @@ export default function AuthPage({ onAuth }: Props) {
     if (res.ok) {
       const data = await res.json();
       localStorage.setItem('token', data.access_token);
+      localStorage.setItem('refresh', data.refresh_token);
       onAuth();
     } else {
       const data = await res.json().catch(() => ({}));

--- a/frontend/src/components/PrincipleSearch.tsx
+++ b/frontend/src/components/PrincipleSearch.tsx
@@ -1,0 +1,37 @@
+import React, { useState } from 'react';
+import { authFetch } from '../api';
+import { Principle } from './PrincipleList';
+
+export default function PrincipleSearch() {
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<Principle[]>([]);
+
+  async function doSearch(e: React.FormEvent) {
+    e.preventDefault();
+    if (!query.trim()) return;
+    const params = new URLSearchParams({ q: query });
+    const res = await authFetch('/api/principles/search?' + params.toString());
+    if (res.ok) {
+      const data = await res.json();
+      setResults(data);
+    }
+  }
+
+  return (
+    <div>
+      <form onSubmit={doSearch}>
+        <input
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search principles"
+        />
+        <button type="submit">Search</button>
+      </form>
+      <ul>
+        {results.map((r) => (
+          <li key={r.id}>{r.text}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/routes.tsx
+++ b/frontend/src/routes.tsx
@@ -3,6 +3,7 @@ import { Routes, Route } from 'react-router-dom';
 import PrincipleList from './components/PrincipleList';
 import PrincipleForm from './components/PrincipleForm';
 import AuthPage from './components/AuthPage';
+import PrincipleSearch from './components/PrincipleSearch';
 import { authFetch } from './api';
 
 export default function AppRoutes() {
@@ -40,6 +41,7 @@ export default function AppRoutes() {
           </div>
         )}
       />
+      <Route path="/search" element={<PrincipleSearch />} />
     </Routes>
   );
 }


### PR DESCRIPTION
## Summary
- add token refresh flow in `authFetch`
- store refresh token on login/signup
- add `PrincipleSearch` component and route

## Testing
- `DATABASE_URL=postgresql://localhost/test make test`

------
https://chatgpt.com/codex/tasks/task_e_688736ac32c4832dbe13ee9e1c48f1c7