### PR TITLE
Add similarity threshold for principle search

### DIFF
--- a/backend/app/principles/routes.py
+++ b/backend/app/principles/routes.py
@@ -22,6 +22,9 @@ from ..models import db, Principle
 from ..schemas import PrincipleOut
 from ..config import Config
 
+# Only return search results that exceed this similarity threshold
+SIMILARITY_THRESHOLD = 0.75
+
 principles_bp = Blueprint('principles', __name__)
 if OFFLINE:
     class _DummyModel:
@@ -83,19 +86,21 @@ def search():
         return jsonify([])
     emb = model.encode(query)
     topk = int(request.args.get('topK', 10))
+    threshold = float(request.args.get('threshold', SIMILARITY_THRESHOLD))
     items = Principle.query.filter_by(user_id=user_id, deleted=False).all()
     results = []
     for p in items:
         vec = np.array(p.embedding)
         sim = float(np.dot(vec, emb) / (np.linalg.norm(vec) * np.linalg.norm(emb)))
-        results.append(
-            {
-                'id': str(p.id),
-                'text': p.text,
-                'created_at': p.created_at.isoformat(),
-                'similarity': sim,
-            }
-        )
+        if sim >= threshold:
+            results.append(
+                {
+                    'id': str(p.id),
+                    'text': p.text,
+                    'created_at': p.created_at.isoformat(),
+                    'similarity': sim,
+                }
+            )
     results.sort(key=lambda r: r['similarity'], reverse=True)
     return jsonify(results[:topk])
 

--- a/frontend/src/components/PrincipleSearch.tsx
+++ b/frontend/src/components/PrincipleSearch.tsx
@@ -4,12 +4,14 @@ import { Principle } from './PrincipleList';
 
 export default function PrincipleSearch() {
   const [query, setQuery] = useState('');
+  // Similarity threshold for search results
+  const THRESHOLD = 0.75;
   const [results, setResults] = useState<Principle[]>([]);
 
   async function doSearch(e: React.FormEvent) {
     e.preventDefault();
     if (!query.trim()) return;
-    const params = new URLSearchParams({ q: query });
+    const params = new URLSearchParams({ q: query, threshold: String(THRESHOLD) });
     const res = await authFetch('/api/principles/search?' + params.toString());
     if (res.ok) {
       const data = await res.json();


### PR DESCRIPTION
## Summary
- filter search results in backend by a similarity threshold
- allow threshold override via `threshold` query param
- send threshold parameter from the frontend search component

## Testing
- `make test` *(fails: ModuleNotFoundError because dependencies could not be installed)*

------
https://chatgpt.com/codex/tasks/task_e_688779f14c0c832d8b197d2c2e76e077